### PR TITLE
Add grouping feature

### DIFF
--- a/src/components/__tests__/test-app.tsx
+++ b/src/components/__tests__/test-app.tsx
@@ -17,6 +17,7 @@ export class TestApp {
           <li><stencil-route-link url="/demo3/page1">Demo3 Page1 Link</stencil-route-link></li>
           <li><stencil-route-link url="/demo3/page2">Demo3 Page2 Link</stencil-route-link></li>
           <li><stencil-route-link url="/demo4">Demo4 Link</stencil-route-link></li>
+          <li><stencil-route-link url="/demo6/">Demo6 Link</stencil-route-link></li>
         </ul>
 
         <stencil-route url="/" exact={true} routeRender={
@@ -64,6 +65,8 @@ export class TestApp {
         ></stencil-route>
 
         <stencil-route url="/demo5" component="async-content" componentProps={{ location: '/' }}></stencil-route>
+
+        <stencil-route url="/demo6" component="test-demo-six"></stencil-route>
       </stencil-router>
     );
   }

--- a/src/components/__tests__/test-demo-six.tsx
+++ b/src/components/__tests__/test-demo-six.tsx
@@ -1,0 +1,39 @@
+import { Component, Prop } from '@stencil/core';
+import { RouterHistory, MatchResults } from '../../global/interfaces';
+
+@Component({
+  tag: 'test-demo-six'
+})
+export class TestDemoSix {
+
+  @Prop() pages: string[];
+  @Prop() match: MatchResults;
+  @Prop() history: RouterHistory;
+
+  render() {
+    console.log('pages: ', this.pages);
+    console.log('match: ', this.match);
+    console.log('history: ', this.history.location);
+
+    return [
+      <span>Demo 6 Test Page<br/></span>,
+      <stencil-route url="/demo6/" exact={true} group="main" routeRender={
+        (props: { [key: string]: any}) => {
+          return [
+            <h1>One</h1>,
+            <stencil-route-link url="/demo6/asdf">Next</stencil-route-link>
+          ];
+        }
+      }></stencil-route>,
+      <stencil-route url="/demo6/:any*" group="main" routeRender={
+        (props: { [key: string]: any}) => {
+          console.log('Got match props:', props.match);
+          return [
+            <h1>Two: {props.match}</h1>,
+            <stencil-route-link url="/demo6/">Back</stencil-route-link>
+          ];
+        }
+      }></stencil-route>
+    ]
+  }
+}

--- a/src/global/interfaces.ts
+++ b/src/global/interfaces.ts
@@ -2,6 +2,14 @@ export interface ActiveRouter {
   subscribe: (callback: Function) => () => void;
   set: (value: {[key: string]: any}) => void;
   get: (attrName?: string) => any;
+  addToGroup: (route: any, groupName: string) => void;
+  removeFromGroups: (route: any) => void;
+  didGroupAlreadyMatch: (groupName: string) => boolean;
+  setGroupMatched: (groupName: string) => void;
+}
+
+export interface Route {
+
 }
 
 export type Listener = () => void;

--- a/stencil.config.js
+++ b/stencil.config.js
@@ -3,7 +3,7 @@ exports.config = {
   generateDistribution: true,
   generateWWW: true,
   bundles: [
-    { components: ['test-app', 'test-demo-three', 'test-demo-four'] },
+    { components: ['test-app', 'test-demo-three', 'test-demo-four', 'test-demo-six'] },
     { components: ['stencil-router', 'stencil-route', 'stencil-route-link', 'stencil-router-redirect', 'stencil-async-content'] }
   ],
   global: 'src/global/router.ts'


### PR DESCRIPTION
This adds a grouping feature, similar to RR's `<Switch>`. Routes can specify a group name using `group="my-group-name"` and then only one matching route in that group will render at a time.