### PR TITLE
fix(route): default scrollTopOffset to 0 so that the default behavior…

### DIFF
--- a/src/components/route/route.tsx
+++ b/src/components/route/route.tsx
@@ -26,7 +26,7 @@ export class Route {
   @Prop() group: string = null;
   @Prop() groupIndex: number = null;
   @Prop() routeRender: Function = null;
-  @Prop() scrollTopOffset: number = null;
+  @Prop() scrollTopOffset: number = 0;
 
   @State() match: MatchResults | null = null;
   @State() activeInGroup: boolean = false;


### PR DESCRIPTION
… when changing pages is to render the new page from the top. Without this set to 0, I often times see my pages scrolled to the very bottom on route change, which results in confusion to users.