### PR TITLE
fix(route): fix issue with scrolling to the bottom of the page when u…

### DIFF
--- a/src/components/route/route.tsx
+++ b/src/components/route/route.tsx
@@ -115,7 +115,13 @@ export class Route {
         window.scrollTo(history.location.scrollPosition[0], history.location.scrollPosition[1]);
       });
     }
-    window.scrollTo(0, this.scrollTopOffset);
+    // read a frame to let things measure correctly
+    return this.queue.read(() => {
+      // okay, the frame has passed. Go ahead and render now
+      return this.queue.write(() => {
+        window.scrollTo(0, this.scrollTopOffset);
+      });
+    });
   }
 
   hostData() {


### PR DESCRIPTION
…sing multiple nested lazy-loaded components


This PR fixes an issue with Stencil Router where if you have nested stencil components, it does not render correctly in ~50% of the cases. Here is a video of the issue to show it clearly. The PR fixes the issue by waiting a frame for everything in the browser to measure correctly, and then executes the scroll.

https://drive.google.com/open?id=1x0025i2quXowcTKRoIXF4GA060q-8CHa

This PR fixes and closes https://github.com/ionic-team/stencil-router/issues/48

Thanks,
Dan