### PR TITLE
feat(): allow alt/ctrl/meta/shift modifiers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:9
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run: npm test

--- a/src/components/route-link/route-link.tsx
+++ b/src/components/route-link/route-link.tsx
@@ -1,5 +1,6 @@
 import { Component, Prop, State } from '@stencil/core';
 import { matchPath } from '../../utils/match-path';
+import { isModifiedEvent } from '../../utils/dom-utils';
 import { RouterHistory, ActiveRouter, Listener, LocationSegments, MatchResults } from '../../global/interfaces';
 
 
@@ -72,6 +73,10 @@ export class RouteLink {
   }
 
   handleClick(e: MouseEvent) {
+    if (isModifiedEvent(e)) {
+      return;
+    }
+
     e.preventDefault();
     if (!this.activeRouter) {
       console.warn(

--- a/src/utils/dom-utils.ts
+++ b/src/utils/dom-utils.ts
@@ -18,6 +18,10 @@ export const getConfirmation = (message: string, callback: (confirmed: boolean) 
   callback(window.confirm(message))
 );
 
+export const isModifiedEvent = (event: MouseEvent) => (
+  event.metaKey || event.altKey || event.ctrlKey || event.shiftKey
+);
+
 /**
  * Returns true if the HTML5 history API is supported. Taken from Modernizr.
  *


### PR DESCRIPTION
This allows modifier keys while handling a click on `stencil-route-link` so that users can still open links in a new tab or window like they're used to.

Right now I'm passing through all modifiers, as I'm not sure which are used on which browsers/platforms:

- `MouseEvent.altKey`
- `MouseEvent.ctrlKey`
- `MouseEvent.metaKey`
- `MouseEvent.shiftKey`
