### PR TITLE
Fixed 0 value causing falsy scrollTopOffset

### DIFF
--- a/packages/router/src/components/switch/switch.tsx
+++ b/packages/router/src/components/switch/switch.tsx
@@ -88,7 +88,7 @@ export class RouteSwitch implements ComponentInterface {
     // Set all props on the new active route then wait until it says that it
     // is completed
     const activeChild = this.subscribers[this.activeIndex];
-    if (this.scrollTopOffset) {
+    if (this.scrollTopOffset || this.scrollTopOffset === 0) {
       activeChild.el.scrollTopOffset = this.scrollTopOffset;
     }
     activeChild.el.group = this.group;
@@ -103,7 +103,7 @@ export class RouteSwitch implements ComponentInterface {
             return child.el.style.display = '';
           }
 
-          if (this.scrollTopOffset) {
+          if (this.scrollTopOffset || this.scrollTopOffset === 0) {
             child.el.scrollTopOffset = this.scrollTopOffset;
           }
           child.el.group = this.group;


### PR DESCRIPTION
Setting scrollTopOffset to 0 would not scroll user back to the top of the page when changing route because when checking for scrollTopOffsets value, 0 would imply there wasn't one (falsy).