### PR TITLE
include url for default routes within match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3918,12 +3918,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3938,17 +3940,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4065,7 +4070,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4077,6 +4083,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4091,6 +4098,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4098,12 +4106,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4122,6 +4132,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4202,7 +4213,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4214,6 +4226,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4335,6 +4348,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/router/package-lock.json
+++ b/packages/router/package-lock.json
@@ -16,8 +16,7 @@
     "@stencil/state-tunnel": {
       "version": "0.0.9-1",
       "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-0.0.9-1.tgz",
-      "integrity": "sha512-Dn04TXjwM+H+1HB6R5B9WwLOKTq/kT/YIwGtAAxiAwYFCugiSWZuE2vf3I8dkCLlEetib5/QAz9MYJ4H4BRKZg==",
-      "dev": true
+      "integrity": "sha512-Dn04TXjwM+H+1HB6R5B9WwLOKTq/kT/YIwGtAAxiAwYFCugiSWZuE2vf3I8dkCLlEetib5/QAz9MYJ4H4BRKZg=="
     },
     "ansi-align": {
       "version": "2.0.0",

--- a/packages/router/src/components/switch/switch.tsx
+++ b/packages/router/src/components/switch/switch.tsx
@@ -18,6 +18,7 @@ function getUniqueId() {
 }
 
 function getMatch(pathname: string, url: any, exact: boolean) {
+  url = (typeof url === undefined) ? pathname : url;
   return matchPath(pathname, {
     path: url,
     exact: exact,

--- a/packages/router/src/utils/match-path.ts
+++ b/packages/router/src/utils/match-path.ts
@@ -48,9 +48,10 @@ export function matchPath(pathname: string, options: MatchOptions = {}): null | 
   if (!match) {
     return null;
   }
-
   const [ url, ...values ] = match;
   const isExact = pathname === url;
+  console.log(pathname);
+  console.log(url);
 
   if (exact && !isExact) {
     return null;


### PR DESCRIPTION
Dear @jthoms1 ,

we make heavily use of the route-switch but not only for not-found-pages, but for dynamic loaded content without assigning every route to a specific component. So in our case it would be helfpul, to include the current "match" within the match object.

example:

```
<stencil-router>
    <stencil-route-switch>
        <stencil-route url='/home' component='il-home' title='home'></stencil-route>
        <stencil-route component='site-loader' title='site'></stencil-route>
    </stencil-route-switch>
</stencil-router>
```

the match result (@Prop() match: MatchResults;) for all default routes (e.g. **/some/url**) looks like this:
```
{path: "/", url: "/", isExact: true, params: {…}}
```
which is not helpful in a fallback case to load any dynamic data. With my suggestion the match result will contain the current url, which can be consumed within the route component:
```
{path: "/some/url", url: "/some/url", isExact: true, params: {…}}
```

Would be cool, if you could merge that. 
Thanx /Alex