### PR TITLE
fix(): test browsers blocking sessionStorage and localStorage prop access

### DIFF
--- a/packages/router/src/utils/dom-utils.ts
+++ b/packages/router/src/utils/dom-utils.ts
@@ -49,6 +49,13 @@ export const isExtraneousPopstateEvent = (nav: Navigator, event: any) => (
 );
 
 export const storageAvailable = (win: any, type: 'localStorage' | 'sessionStorage') => {
+  try {
+    // test for errors thrown when accessing the property
+    win[type];
+  } catch(e) {
+    return false;
+  }
+
   const storage = win[type];
   const x = '__storage_test__';
 


### PR DESCRIPTION
Browsers like Brave block cross-domain cookies and storage by default. This blocking goes so far that in the case of Brave browser (and probably others as well) immediately an error is thrown even when just accessing the `window.localStorage` or `window.sessionStorage` property.