### PR TITLE
fix(link): href of router-link does not check root path

### DIFF
--- a/packages/router/src/components/route-link/route-link.tsx
+++ b/packages/router/src/components/route-link/route-link.tsx
@@ -92,10 +92,12 @@ export class RouteLink implements ComponentInterface {
       anchorAttributes.class[this.anchorClass] = true;
     }
 
+    const href = this.url && this.root ?  getUrl(this.url, this.root) : this.url;
+
     if (this.custom === 'a') {
       anchorAttributes = {
         ...anchorAttributes,
-        href: this.url,
+        href: href,
         title: this.anchorTitle,
         role: this.anchorRole,
         tabindex: this.anchorTabIndex,


### PR DESCRIPTION
When "root" of router is "/foo" and "url" of router-link is "/bar", href of router-link should be "/foo/bar". But the href is "/bar" now. It becomes a problem when user do "Open Link in New Tab".