### PR TITLE
chore(ownership): move stencil router to community

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ Included components and all other information can be found in our [wiki].
 
 [wiki]: https://github.com/ionic-team/stencil-router/wiki
 
-[npm-badge]: https://img.shields.io/npm/v/@stencil/router.svg
-[npm-badge-url]: https://www.npmjs.com/package/@stencil/router
+[npm-badge]: https://img.shields.io/npm/v/@stencil-community/router.svg
+[npm-badge-url]: https://www.npmjs.com/package/@stencil-community/router

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stencil/router",
+  "name": "@stencil-community/router",
   "version": "1.0.1",
   "description": "Stencil Router",
   "main": "dist/index.js",


### PR DESCRIPTION
this is the first commit necessary to move the router to the community
model. it changes the name of the package to `@stencil-community/router`
(from `@stencil/router`).

this commit does not update the demo package, as the router has not been
published to the (npm) package registry prior to this commit landing.
once this commit has landed, the demo package will be updated